### PR TITLE
[apc] Remove bad first 'user' parameter

### DIFF
--- a/cache.php
+++ b/cache.php
@@ -171,7 +171,7 @@
 	}
 
 	if( isset( $_GET['action'] ) && $_GET['action'] == 'apcu_delete' ) {
-		apcu_delete( new ApcuIterator('user',get_selector()) );
+		apcu_delete( new ApcuIterator(get_selector()) );
 		redirect( '?action=apcu_select&selector=' . $_GET['selector'] );
 	}
 ?><html>


### PR DESCRIPTION
Follows-up 2d994a2 and b403699e.